### PR TITLE
Fix commentTokens definition

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -3,7 +3,7 @@ import {Language, defineLanguageFacet, languageDataProp, foldNodeProp, indentNod
 import {parser as baseParser, MarkdownParser, GFM, Subscript, Superscript, Emoji} from "@lezer/markdown"
 import {SyntaxNode, NodeType, NodeProp} from "@lezer/common"
 
-const data = defineLanguageFacet({block: {open: "<!--", close: "-->"}})
+const data = defineLanguageFacet({commentTokens: {block: {open: "<!--", close: "-->"}}})
 
 const headingProp = new NodeProp<number>()
 


### PR DESCRIPTION
I am not sure if I understand this correctly, was this an oversight? Feel free to close this PR if I am wrong.

Markdown does support comments by inheriting from HTML syntax, and the definition in lang-markdown seems to be correct.

However, it seems the declaration of `defineLanguageFacet` doesn't follow the `languageData` definition, which starts with a `commentTokens` scope.

It got comment features enabled after adding this.