### PR TITLE
feat: export mkLang to help extend the parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
     "@codemirror/language": "^6.3.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@lezer/markdown": "^1.0.0",
-    "@lezer/common": "^1.0.0"
+    "@lezer/common": "^1.0.0",
+    "@lezer/markdown": "^1.0.0"
   },
   "devDependencies": {
-    "@codemirror/buildhelper": "^1.0.0"
+    "@codemirror/buildhelper": "^1.0.0",
+    "@types/mocha": "^10.0.3",
+    "ist": "^1.1.7",
+    "mocha": "^10.2.0"
   },
   "repository": {
     "type": "git",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
-import {StateCommand, Text, EditorState, EditorSelection, ChangeSpec, countColumn} from "@codemirror/state"
-import {syntaxTree, indentUnit} from "@codemirror/language"
-import {SyntaxNode, Tree} from "@lezer/common"
-import {markdownLanguage} from "./markdown"
+import { indentUnit, syntaxTree } from "@codemirror/language"
+import { ChangeSpec, EditorSelection, EditorState, SelectionRange, StateCommand, Text, countColumn } from "@codemirror/state"
+import { SyntaxNode, Tree } from "@lezer/common"
+import { markdownLanguage } from "./markdown"
 
 class Context {
   constructor(
@@ -32,12 +32,12 @@ class Context {
 }
 
 function getContext(node: SyntaxNode, doc: Text) {
-  let nodes = []
+  let nodes: SyntaxNode[] = []
   for (let cur: SyntaxNode | null = node; cur && cur.name != "Document"; cur = cur.parent) {
     if (cur.name == "ListItem" || cur.name == "Blockquote" || cur.name == "FencedCode")
       nodes.push(cur)
   }
-  let context = []
+  let context: Context[] = []
   for (let i = nodes.length - 1; i >= 0; i--) {
     let node = nodes[i], match
     let line = doc.lineAt(node.from), startPos = node.from - line.from
@@ -106,7 +106,7 @@ function normalizeIndent(content: string, state: EditorState) {
 /// document, HTML and code regions might use a different language).
 export const insertNewlineContinueMarkup: StateCommand = ({state, dispatch}) => {
   let tree = syntaxTree(state), {doc} = state
-  let dont = null, changes = state.changeByRange(range => {
+  let dont: { range: SelectionRange; } | null = null, changes = state.changeByRange(range => {
     if (!range.empty || !markdownLanguage.isActiveAt(state, range.from)) return dont = {range}
     let pos = range.from, line = doc.lineAt(pos)
     let context = getContext(tree.resolveInner(pos, -1), doc)
@@ -210,7 +210,7 @@ function contextNodeForDelete(tree: Tree, pos: number) {
 /// commands, with a higher precedence than the more generic commands.
 export const deleteMarkupBackward: StateCommand = ({state, dispatch}) => {
   let tree = syntaxTree(state)
-  let dont = null, changes = state.changeByRange(range => {
+  let dont: { range: SelectionRange; } | null = null, changes = state.changeByRange(range => {
     let pos = range.from, {doc} = state
     if (range.empty && markdownLanguage.isActiveAt(state, range.from)) {
       let line = doc.lineAt(pos)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import {Prec, EditorState} from "@codemirror/state"
-import {KeyBinding, keymap} from "@codemirror/view"
-import {Language, LanguageSupport, LanguageDescription, syntaxTree} from "@codemirror/language"
-import {Completion, CompletionContext} from "@codemirror/autocomplete"
-import {MarkdownExtension, MarkdownParser, parseCode} from "@lezer/markdown"
-import {html, htmlCompletionSource} from "@codemirror/lang-html"
-import {commonmarkLanguage, markdownLanguage, mkLang, getCodeParser} from "./markdown"
-import {insertNewlineContinueMarkup, deleteMarkupBackward} from "./commands"
-export {commonmarkLanguage, markdownLanguage, insertNewlineContinueMarkup, deleteMarkupBackward}
+import { Completion, CompletionContext } from "@codemirror/autocomplete"
+import { html, htmlCompletionSource } from "@codemirror/lang-html"
+import { Language, LanguageDescription, LanguageSupport, syntaxTree } from "@codemirror/language"
+import { EditorState, Prec } from "@codemirror/state"
+import { KeyBinding, keymap } from "@codemirror/view"
+import { MarkdownExtension, MarkdownParser, parseCode } from "@lezer/markdown"
+import { deleteMarkupBackward, insertNewlineContinueMarkup } from "./commands"
+import { commonmarkLanguage, getCodeParser, markdownLanguage, mkLang } from "./markdown"
+export { commonmarkLanguage, deleteMarkupBackward, insertNewlineContinueMarkup, markdownLanguage, mkLang }
 
 /// A small keymap with Markdown-specific bindings. Binds Enter to
 /// [`insertNewlineContinueMarkup`](#lang-markdown.insertNewlineContinueMarkup)

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,7 +1,15 @@
-import {Language, defineLanguageFacet, languageDataProp, foldNodeProp, indentNodeProp, foldService,
-        syntaxTree, LanguageDescription, ParseContext} from "@codemirror/language"
-import {parser as baseParser, MarkdownParser, GFM, Subscript, Superscript, Emoji} from "@lezer/markdown"
-import {SyntaxNode, NodeType, NodeProp} from "@lezer/common"
+import {
+  Language,
+  LanguageDescription, ParseContext,
+  defineLanguageFacet,
+  foldNodeProp,
+  foldService,
+  indentNodeProp,
+  languageDataProp,
+  syntaxTree
+} from "@codemirror/language"
+import { NodeProp, NodeType, SyntaxNode } from "@lezer/common"
+import { Emoji, GFM, MarkdownParser, Subscript, Superscript, parser as baseParser } from "@lezer/markdown"
 
 const data = defineLanguageFacet({commentTokens: {block: {open: "<!--", close: "-->"}}})
 
@@ -68,7 +76,7 @@ export function getCodeParser(
 ) {
   return (info: string) => {
     if (info && languages) {
-      let found = null
+      let found: Language | LanguageDescription | null = null
       // Strip anything after whitespace
       info = /\S*/.exec(info)![0]
       if (typeof languages == "function") found = languages(info)

--- a/test/test-commands.ts
+++ b/test/test-commands.ts
@@ -2,9 +2,10 @@ import {EditorState, EditorSelection, StateCommand, Extension} from "@codemirror
 import {markdown, deleteMarkupBackward, insertNewlineContinueMarkup} from "@codemirror/lang-markdown"
 import {indentUnit} from "@codemirror/language"
 import ist from "ist"
+import { SelectionRange } from "@codemirror/state"
 
 function mkState(doc: string, extension?: Extension) {
-  let cursors = []
+  let cursors: SelectionRange[] = []
   for (let pos = 0;;) {
     pos = doc.indexOf("|", pos)
     if (pos < 0) break


### PR DESCRIPTION
I am trying to extend the GFM markdown parser.  
However, the package only exports commonmark and GFM Langauges.  
I know I can retrieve `MarkdownParser` by those ways
```typescript
const commonmarkParser = commonmarkLanguage.parser as MarkdownParser;
const extendedParser = markdownLanguage.parser as MarkdownParser;
```
However, I cannot recreate `Language` from `MarkdownParser` since `mkLang` is not exported by the package.  

This PR exports `mkLang` from the package.

## Examples
In order to extend the GFM Parser currently, the bolierplate code should be copied.
```typescript
import { markdownLanguage } from "@codemirror/lang-markdown";
import {
  Language,
  defineLanguageFacet,
  foldService,
  syntaxTree,
} from "@codemirror/language";
import { NodeProp, NodeType, SyntaxNode } from "@lezer/common";
import { MarkdownParser } from "@lezer/markdown";
import { HeaderContent } from "./HeaderContent";

const data = defineLanguageFacet({
  commentTokens: { block: { open: "<!--", close: "-->" } },
});

const headingProp = new NodeProp<number>();

function isHeading(type: NodeType) {
  let match = /^(?:ATX|Setext)Heading(\d)$/.exec(type.name);
  return match ? +match[1] : undefined;
}

function findSectionEnd(headerNode: SyntaxNode, level: number) {
  let last = headerNode;
  for (;;) {
    let next = last.nextSibling,
      heading;
    if (!next || ((heading = isHeading(next.type)) != null && heading <= level))
      break;
    last = next;
  }
  return last.to;
}

const headerIndent = foldService.of((state, start, end) => {
  for (
    let node: SyntaxNode | null = syntaxTree(state).resolveInner(end, -1);
    node;
    node = node.parent
  ) {
    if (node.from < start) break;
    let heading = node.type.prop(headingProp);
    if (heading == null) continue;
    let upto = findSectionEnd(node, heading);
    if (upto > end) return { from: end, to: upto };
  }
  return null;
});

function mkLang(parser: MarkdownParser) {
  return new Language(data, parser, [headerIndent], "markdown");
}

const extendedParser = markdownLanguage.parser as MarkdownParser;
const extended = extendedParser.configure([HeaderContent]);
export const customMarkdownLanguage = mkLang(extended);
```

If the `mkLang` is exported, we can remove this boilerplate code.
```typescript
// Copied from @codemirror/lang-markdown

import { markdownLanguage, mkLang } from "@codemirror/lang-markdown";
import { MarkdownParser } from "@lezer/markdown";
import { HeaderContent } from "./HeaderContent";

const extendedParser = markdownLanguage.parser as MarkdownParser;
const extended = extendedParser.configure([HeaderContent]);
export const customMarkdownLanguage = mkLang(extended);
```