### PR TITLE
Update @lezer/markdown dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@codemirror/language": "^6.3.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
-    "@lezer/markdown": "^1.0.0",
+    "@lezer/markdown": "^1.1.2",
     "@lezer/common": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

After upgrading `@codemirror/lang-markdown` to the latest version, I had an issue where new list items weren't automatically inserted when pressing `Enter` with the cursor at the end of an item in a list.

I was able to fix it by upgrading the `@lezer/markdown` package to the latest version. It took a little while figuring out what the problem was since I hadn't installed the `@lezer/markdown` explicitly. Here's a PR that bumps the required version of `@lezer/markdown`. 

Best,
Jonatan