### PR TITLE
support creating a `Language` with just a `Parser`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export function markdown(config: {
   extensions?: MarkdownExtension,
   /// The base language to use. Defaults to
   /// [`commonmarkLanguage`](#lang-markdown.commonmarkLanguage).
-  base?: Language,
+  base?: Pick<Language, 'parser'>,
   /// By default, the extension installs an autocompletion source that
   /// completes HTML tags when a `<` is typed. Set this to false to
   /// disable this.


### PR DESCRIPTION
i couldn't find a way to create a new `LanguageSupport` or `Language` by extending the commonmark/GFM flavored markdowns already defined in this package. After reading through the source, it seems it was most intended to use the `markdown` function to do this. however, the type constraints on the argument to that function make this infeasible, having to write something like:

```ts
import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
import type { LanguageSupport } from '@codemirror/language';
import { parser as markdownParser } from '@lezer/markdown';

markdownLanguage.parser = markdownParser.configure({})

const markdownLanguageSupport: LanguageSupport = markdown({
	base: markdownLanguage,
});
```

this change is API-compatible and allows accomplishing what i'm trying to accomplish like the following. note that only the `parser` field of the `base` arg is actually used within the `markdown` function
```ts
import { markdown } from '@codemirror/lang-markdown';
import type { LanguageSupport } from '@codemirror/language';
import { parser as markdownParser } from '@lezer/markdown';
const markdownLanguageSupport: LanguageSupport = markdown({
	base: { parser: markdownParser.configure({}) },
});
```